### PR TITLE
update base image to use dumb-init to launch node.js process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM cmosetick/alpine-dumb-init:node-8
 
 ENV NPM_CONFIG_LOGLEVEL warn
 


### PR DESCRIPTION
overcome node.js PID1 problem with `dumb-init`